### PR TITLE
The Graph::BFS() function ignores root parameter.  This fixes the issue.

### DIFF
--- a/pygraphml/graph.py
+++ b/pygraphml/graph.py
@@ -76,11 +76,9 @@ class Graph:
             root = self.root()
 
         queue = deque()
-        queue.append(self.root())
+        queue.append(root)
 
         nodes = []
-
-        self.depth = 0
 
         while len(queue) > 0:
             x = queue.popleft()


### PR DESCRIPTION
The Graph::BFS() function takes a single argument specifying the node from which to start the breadth-first-search.  However, line 79 of
graph.py prevented the parameter from being applied.  I also removed
line 83 because the self.depth value is not used anywhere in the
package.
-Josh