### PR TITLE
Fixing GraphMLParser.parse

### DIFF
--- a/pygraphml/graph.py
+++ b/pygraphml/graph.py
@@ -118,11 +118,11 @@ class Graph:
 
         return node.children()
 
-    def add_node(self, label=""):
+    def add_node(self, label="", id=None):
         """
         """
 
-        n = Node()
+        n = Node(id)
         n['label'] = label
         self._nodes.append(n)
 
@@ -141,6 +141,17 @@ class Graph:
         self._edges.append(e)
 
         return e
+
+    def add_edge_by_id(self, id1, id2):
+        try:
+            n1 = next(n for n in self._nodes if n.id == int(id1))
+        except StopIteration:
+            raise ValueError('Graph has no node with ID {}'.format(id1))
+        try:
+            n2 = next(n for n in self._nodes if n.id == int(id2))
+        except StopIteration:
+            raise ValueError('Graph has no node with ID {}'.format(id2))
+        return self.add_edge(n1, n2)
 
     def add_edge_by_label(self, label1, label2):
         """

--- a/pygraphml/graphml_parser.py
+++ b/pygraphml/graphml_parser.py
@@ -97,7 +97,7 @@ class GraphMLParser:
 
             # Get nodes
             for node in graph.getElementsByTagName("node"):
-                n = g.add_node(node.getAttribute('id'))
+                n = g.add_node(id=node.getAttribute('id'))
 
                 for attr in node.getElementsByTagName("data"):
                     if attr.firstChild:
@@ -109,7 +109,9 @@ class GraphMLParser:
             for edge in graph.getElementsByTagName("edge"):
                 source = edge.getAttribute('source')
                 dest = edge.getAttribute('target')
-                e = g.add_edge_by_label(source, dest)
+
+                # source/target attributes refer to IDs: http://graphml.graphdrawing.org/xmlns/1.1/graphml-structure.xsd
+                e = g.add_edge_by_id(source, dest)
 
                 for attr in edge.getElementsByTagName("data"):
                     if attr.firstChild:

--- a/pygraphml/item.py
+++ b/pygraphml/item.py
@@ -14,13 +14,12 @@ class Item(object):
 
     ID = 0
 
-    def __init__(self):
-        """
-        """
-
-        self.id = Item.ID
-        Item.ID += 1
-
+    def __init__(self, id=None):
+        if id is None:
+            self.id = Item.ID
+            Item.ID += 1
+        else:
+            self.id = int(id)
         self.attr = {}
 
     def __str__(self):

--- a/pygraphml/node.py
+++ b/pygraphml/node.py
@@ -12,11 +12,11 @@ class Node(Item):
     """
     """
 
-    def __init__(self):
+    def __init__(self, id=None):
         """
         """
 
-        super(Node, self).__init__()
+        super(Node, self).__init__(id)
 
         self._edges = []
 


### PR DESCRIPTION
This PR fixes 2 issues in `GraphMLParser.parse`:
- `Graph.add_node` is called with the node ID, while the method excepts a label.
Now the node ID is properly set.
- it used to call `Graph.add_edge_by_label` whereas the GraphML spec indicate that source/target attributes refer to IDs, not labels: http://graphml.graphdrawing.org/xmlns/1.1/graphml-structure.xsd