### PR TITLE
Fix: allowing for non-integer node IDs

### DIFF
--- a/pygraphml/graph.py
+++ b/pygraphml/graph.py
@@ -144,11 +144,11 @@ class Graph:
 
     def add_edge_by_id(self, id1, id2):
         try:
-            n1 = next(n for n in self._nodes if n.id == int(id1))
+            n1 = next(n for n in self._nodes if n.id == id1)
         except StopIteration:
             raise ValueError('Graph has no node with ID {}'.format(id1))
         try:
-            n2 = next(n for n in self._nodes if n.id == int(id2))
+            n2 = next(n for n in self._nodes if n.id == id2)
         except StopIteration:
             raise ValueError('Graph has no node with ID {}'.format(id2))
         return self.add_edge(n1, n2)

--- a/pygraphml/item.py
+++ b/pygraphml/item.py
@@ -16,10 +16,10 @@ class Item(object):
 
     def __init__(self, id=None):
         if id is None:
-            self.id = Item.ID
+            self.id = str(Item.ID)
             Item.ID += 1
         else:
-            self.id = int(id)
+            self.id = id
         self.attr = {}
 
     def __str__(self):


### PR DESCRIPTION
Hi.

In https://github.com/hadim/pygraphml/pull/20 I introduced an integer convertion of node IDs,
whereas the spec allow for any string (`xs:NMTOKEN`): http://graphml.graphdrawing.org/xmlns/1.1/graphml-structure.xsd

This commit removes this regression.