### PR TITLE
Get an XML string from GraphMLParser's write() w/o writing it to a file

### DIFF
--- a/pygraphml/graphml_parser.py
+++ b/pygraphml/graphml_parser.py
@@ -20,7 +20,7 @@ class GraphMLParser:
         """
         """
 
-    def write(self, graph, fname):
+    def write(self, graph, fname=None):
         """
         """
 
@@ -74,8 +74,11 @@ class GraphMLParser:
                     edge.appendChild(data)
             graph_node.appendChild(edge)
 
-        f = open(fname, 'w')
-        f.write(doc.toprettyxml(indent = '    '))
+        if fname is not None:
+            f = open(fname, 'w')
+            f.write(doc.toprettyxml(indent='    '))
+        else:
+            return doc.toprettyxml(indent='', newl='')
 
     def parse(self, fname):
         """


### PR DESCRIPTION
I'd like to be able to get an XML string from GraphMLParser's `write()` w/o writing it to a file. I turned `fname` in `write()` into an optional argument for this purpose. What do you think?