### PR TITLE
Add optional encoding param in GraphMLParser.write()

### DIFF
--- a/pygraphml/graphml_parser.py
+++ b/pygraphml/graphml_parser.py
@@ -18,7 +18,7 @@ class GraphMLParser:
         """
         """
 
-    def write(self, graph, fname=None):
+    def write(self, graph, fname=None, enc=None):
         """
         """
 
@@ -73,7 +73,7 @@ class GraphMLParser:
             graph_node.appendChild(edge)
 
         if fname is not None:
-            f = open(fname, 'w')
+            f = open(fname, 'w', encoding=enc)
             f.write(doc.toprettyxml(indent='    '))
         else:
             return doc.toprettyxml(indent='', newl='')


### PR DESCRIPTION
Just a small fix so that it works better with different encodings, especially when the default encoding of the system is not utf-8.