### PR TITLE
label position bug fix

### DIFF
--- a/pygraphml/graph.py
+++ b/pygraphml/graph.py
@@ -241,10 +241,11 @@ class Graph:
                 n2_label = e.node2.id
             G.add_edge(n1_label, n2_label)
 
-        nx.draw(G)
-
+        pos = None
         if show_label:
-            nx.draw_networkx_labels(G, pos=nx.spring_layout(G))
+            pos = nx.spring_layout(G)
+            nx.draw_networkx_labels(G, pos=pos)
+        nx.draw(G, pos=pos)
 
         plt.show()
 


### PR DESCRIPTION
## Issue

Label position is not properly set.

## Solution

set label position when calling `.draw`.

## Current

<img width="752" alt="Screen Shot 2023-03-17 at 21 59 40" src="https://user-images.githubusercontent.com/8680072/225911677-98196e95-45da-4819-9463-d00974519e38.png">

## After merge

<img width="752" alt="Screen Shot 2023-03-17 at 22 00 02" src="https://user-images.githubusercontent.com/8680072/225911635-13527fed-5d0e-425a-8d6a-41b0dfd54580.png">
